### PR TITLE
Improve dependency management

### DIFF
--- a/ltree_hierarchy.gemspec
+++ b/ltree_hierarchy.gemspec
@@ -17,11 +17,7 @@ Gem::Specification.new do |s|
   s.platform          = Gem::Platform::RUBY
   s.require_paths     = ["lib"]
 
-  if ENV['RAILS_3_1']
-    s.add_dependency 'activerecord', '~> 3.1.0'
-  else
-    s.add_dependency 'activerecord', '~> 3.2.0'
-  end
+  s.add_dependency 'activerecord', '~> 3.1'
 
   s.add_dependency 'pg'
 


### PR DESCRIPTION
- As the next version of Rails is 4 and this Gem is compatible with 3.1 and 3.2, then the restriction can be less restrictive ;-)
