### PR TITLE
Use lighter #exists? instead of #any?

### DIFF
--- a/lib/ltree_hierarchy/hierarchy.rb
+++ b/lib/ltree_hierarchy/hierarchy.rb
@@ -133,7 +133,7 @@ module Ltree
       end
 
       def leaf?
-        !children.any?
+        !children.exists?
       end
 
       def depth # 1-based, for compatibility with ltree's nlevel().


### PR DESCRIPTION
`exists?` does a "SELECT 1 AS one" instead of "SELECT tree_nodes.*"
