### PR TITLE
Add primary key on belongs to.

### DIFF
--- a/lib/ltree_hierarchy/hierarchy.rb
+++ b/lib/ltree_hierarchy/hierarchy.rb
@@ -15,7 +15,7 @@ module Ltree
       self.ltree_parent_fragment_column = options[:parent_fragment]
       self.ltree_path_column = options[:path]
 
-      belongs_to :parent, class_name: name, foreign_key: ltree_parent_fragment_column
+      belongs_to :parent, class_name: name, foreign_key: ltree_parent_fragment_column, primary_key: ltree_fragment_column
 
       validate :prevent_circular_paths, if: :ltree_parent_fragment_changed?
 


### PR DESCRIPTION
The idea here is to not assume the assocations primary key is
the fragment column.  Loosing this assumption allows for more
flexibility.