### PR TITLE
Change .roots to .root in ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Run migrations:
   subchild.root # => root
 ```
 
-- `.roots`
+- `.root`
 - `.leaves`
 - `.at_depth(n)`
 - `.lowest_common_ancestors(scope)`


### PR DESCRIPTION
`.roots` is not a method, I believe `.root` is the one you guys meant to reference.