### PR TITLE
Upgrade dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ branches:
   only:
     - master
 rvm:
-  - 2.3.3
+  - 2.4.1
 gemfile:
   - test/gemfiles/Gemfile.rails-4.2.x
   - test/gemfiles/Gemfile.rails-5.0.x
+  - test/gemfiles/Gemfile.rails-5.2.x

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,4 @@ branches:
 rvm:
   - 2.4.1
 gemfile:
-  - test/gemfiles/Gemfile.rails-4.2.x
-  - test/gemfiles/Gemfile.rails-5.0.x
   - test/gemfiles/Gemfile.rails-5.2.x

--- a/ltree_hierarchy.gemspec
+++ b/ltree_hierarchy.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.license = "MIT"
   s.require_paths = ["lib"]
 
-  s.add_dependency "pg"
+  s.add_dependency "pg", "~> 1.1.0"
 
   s.add_dependency "activerecord", ">= 4.2.0"
 

--- a/ltree_hierarchy.gemspec
+++ b/ltree_hierarchy.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
 
   s.add_dependency "pg", "~> 1.1.0"
 
-  s.add_dependency "activerecord", ">= 4.2.0"
+  s.add_dependency "activerecord", ">= 5.2.0"
 
   s.add_development_dependency "minitest"
   s.add_development_dependency "rake"

--- a/test/gemfiles/Gemfile.rails-4.2.x
+++ b/test/gemfiles/Gemfile.rails-4.2.x
@@ -1,4 +1,0 @@
-source "https://rubygems.org"
-gemspec path: "./../.."
-
-gem "activerecord", "~> 4.2.0"

--- a/test/gemfiles/Gemfile.rails-5.0.x
+++ b/test/gemfiles/Gemfile.rails-5.0.x
@@ -1,4 +1,0 @@
-source "https://rubygems.org"
-gemspec path: "./../.."
-
-gem "activerecord", "~> 4.2.0"

--- a/test/gemfiles/Gemfile.rails-5.2.x
+++ b/test/gemfiles/Gemfile.rails-5.2.x
@@ -1,0 +1,4 @@
+source "https://rubygems.org"
+gemspec path: "./../.."
+
+gem "activerecord", "~> 5.2.0"


### PR DESCRIPTION
Remove support for Rails 4.2 and 5.0.
The gem pg 1.1 is supported only by Rails 5.2. Others have an [issue](https://github.com/rails/rails/issues/31673) with loading pg.